### PR TITLE
Support handling 304 status code in onResponse flow

### DIFF
--- a/dio_cache_interceptor/CHANGELOG.md
+++ b/dio_cache_interceptor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.3
+- fix: Correctly sierialize null content responses.
+- chore: explicitly allow dart 3.
+
 ## 3.4.2
 - fix: Headers were not saved/restored in/from `CacheResponse`.
 - fix: Cache trigger now enabled again with `expires`, `Cache-Control`/`max-age`.

--- a/dio_cache_interceptor/CHANGELOG.md
+++ b/dio_cache_interceptor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.2
+- fix: Headers were not saved/restored in/from `CacheResponse`.
+- fix: Cache trigger now enabled again with `expires`, `Cache-Control`/`max-age`.
+- feat: Add few new status codes available for caching: 404, 405 and 501.
+- chore: Few code improvements.
+
 ## 3.4.1
 - chore: Ensure header values are join when there's comma (,) in the value (date, expires, last-modified, etag).
 Dio may or may not understand headers with single value (i.e.: 'Wed, 21 Oct 2015 07:28:00 GMT').

--- a/dio_cache_interceptor/CHANGELOG.md
+++ b/dio_cache_interceptor/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.4.3
 - fix: Correctly sierialize null content responses.
 - chore: explicitly allow dart 3.
+- chore: Now requires Dio >= 5.2.0+1.
 
 ## 3.4.2
 - fix: Headers were not saved/restored in/from `CacheResponse`.

--- a/dio_cache_interceptor/CHANGELOG.md
+++ b/dio_cache_interceptor/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.4
+- chore: Allow UUID package version v4.x
+
 ## 3.4.3
 - fix: Correctly sierialize null content responses.
 - chore: explicitly allow dart 3.

--- a/dio_cache_interceptor/README.md
+++ b/dio_cache_interceptor/README.md
@@ -61,6 +61,9 @@ final options = const CacheOptions(
   // Default. Allows to cache POST requests.
   // Overriding [keyBuilder] is strongly recommended when [true].
   allowPostMethod: false,
+  // handle not-modified status in response flow
+  // This allows following response interceptors to still be called
+  callResponseInterceptorsAfterNotModified: false,
 );
 
 // Add cache interceptor with global/default options

--- a/dio_cache_interceptor/example/pubspec.yaml
+++ b/dio_cache_interceptor/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use dio cache interceptor lib.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   flutter:

--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -101,7 +101,7 @@ class DioCacheInterceptor extends Interceptor {
 
   @override
   void onError(
-    DioError err,
+    DioException err,
     ErrorInterceptorHandler handler,
   ) async {
     final cacheOptions = _getCacheOptions(err.requestOptions);
@@ -154,9 +154,9 @@ class DioCacheInterceptor extends Interceptor {
     RequestOptions? request, {
     required CacheOptions options,
     Response? response,
-    DioError? error,
+    DioException? error,
   }) {
-    if (error?.type == DioErrorType.cancel) {
+    if (error?.type == DioExceptionType.cancel) {
       return true;
     }
 

--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -30,6 +30,11 @@ class DioCacheInterceptor extends Interceptor {
 
     final cacheOptions = _getCacheOptions(options);
 
+    if (cacheOptions.callResponseInterceptorsAfterNotModified) {
+      // Add 304 as a valid status so onResponse flow is used when a 304 occurs
+      options.validateStatus = (status) => options.validateStatus(status) || status == 304;
+    }
+
     if (_shouldSkip(options, options: cacheOptions)) {
       handler.next(options);
       return;

--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -214,7 +214,8 @@ class DioCacheInterceptor extends Interceptor {
     if (response != null) {
       // Purge entry if staled
       final maxStale = CacheOptions.fromExtra(request)?.maxStale;
-      if ((maxStale == null || maxStale == const Duration(microseconds: 0)) && response.isStaled()) {
+      if ((maxStale == null || maxStale == const Duration(microseconds: 0)) &&
+          response.isStaled()) {
         await cacheStore.delete(cacheKey);
         return null;
       }
@@ -246,7 +247,8 @@ class DioCacheInterceptor extends Interceptor {
 
       // Update extra fields with cache info
       response.extra[CacheResponse.cacheKey] = cacheResp.key;
-      response.extra[CacheResponse.fromNetwork] = CacheStrategyFactory.allowedStatusCodes.contains(statusCode);
+      response.extra[CacheResponse.fromNetwork] =
+          CacheStrategyFactory.allowedStatusCodes.contains(statusCode);
     }
   }
 

--- a/dio_cache_interceptor/lib/src/model/cache_options.dart
+++ b/dio_cache_interceptor/lib/src/model/cache_options.dart
@@ -77,6 +77,10 @@ class CacheOptions {
   /// allow POST method request to be cached.
   final bool allowPostMethod;
 
+  /// handle not-modified status in response flow
+  /// This allows following response interceptors to still be called
+  final bool callResponseInterceptorsAfterNotModified;
+
   // Key to retrieve options from request
   static const _extraKey = '@cache_options@';
 
@@ -91,6 +95,7 @@ class CacheOptions {
     this.priority = CachePriority.normal,
     this.cipher,
     this.allowPostMethod = false,
+    this.callResponseInterceptorsAfterNotModified = false,
     required this.store,
   });
 
@@ -119,6 +124,7 @@ class CacheOptions {
     CacheStore? store,
     Nullable<CacheCipher>? cipher,
     bool? allowPostMethod,
+    bool? callResponseInterceptorsAfterNotModified,
   }) {
     return CacheOptions(
       policy: policy ?? this.policy,
@@ -131,6 +137,8 @@ class CacheOptions {
       store: store ?? this.store,
       cipher: cipher != null ? cipher.value : this.cipher,
       allowPostMethod: allowPostMethod ?? this.allowPostMethod,
+      callResponseInterceptorsAfterNotModified:
+          callResponseInterceptorsAfterNotModified ?? this.callResponseInterceptorsAfterNotModified,
     );
   }
 }

--- a/dio_cache_interceptor/lib/src/model/cache_options.dart
+++ b/dio_cache_interceptor/lib/src/model/cache_options.dart
@@ -77,10 +77,6 @@ class CacheOptions {
   /// allow POST method request to be cached.
   final bool allowPostMethod;
 
-  /// handle not-modified status in response flow
-  /// This allows following response interceptors to still be called
-  final bool callResponseInterceptorsAfterNotModified;
-
   // Key to retrieve options from request
   static const _extraKey = '@cache_options@';
 
@@ -95,7 +91,6 @@ class CacheOptions {
     this.priority = CachePriority.normal,
     this.cipher,
     this.allowPostMethod = false,
-    this.callResponseInterceptorsAfterNotModified = false,
     required this.store,
   });
 
@@ -124,7 +119,6 @@ class CacheOptions {
     CacheStore? store,
     Nullable<CacheCipher>? cipher,
     bool? allowPostMethod,
-    bool? callResponseInterceptorsAfterNotModified,
   }) {
     return CacheOptions(
       policy: policy ?? this.policy,
@@ -137,8 +131,6 @@ class CacheOptions {
       store: store ?? this.store,
       cipher: cipher != null ? cipher.value : this.cipher,
       allowPostMethod: allowPostMethod ?? this.allowPostMethod,
-      callResponseInterceptorsAfterNotModified:
-          callResponseInterceptorsAfterNotModified ?? this.callResponseInterceptorsAfterNotModified,
     );
   }
 }

--- a/dio_cache_interceptor/lib/src/util/content_serialization.dart
+++ b/dio_cache_interceptor/lib/src/util/content_serialization.dart
@@ -3,7 +3,11 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
-Future<List<int>> serializeContent(ResponseType type, dynamic content) async {
+Future<List<int>?> serializeContent(ResponseType type, dynamic content) async {
+  if (content == null) {
+    return null;
+  }
+
   switch (type) {
     case ResponseType.bytes:
       return content;

--- a/dio_cache_interceptor/pubspec.yaml
+++ b/dio_cache_interceptor/pubspec.yaml
@@ -3,16 +3,16 @@ description: Dio HTTP cache interceptor with multiple stores respecting HTTP dir
 repository: https://github.com/llfbandit/dio_cache_interceptor
 issue_tracker: https://github.com/llfbandit/dio_cache_interceptor/issues
 
-version: 3.4.2
+version: 3.4.3
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   # https://pub.dev/packages/dio
   dio: ">=4.0.0 <6.0.0"  
   # https://pub.dev/packages/uuid
-  uuid: ^3.0.4
+  uuid: ^3.0.7
   # https://pub.dev/packages/string_scanner
   string_scanner: ^1.1.0
 

--- a/dio_cache_interceptor/pubspec.yaml
+++ b/dio_cache_interceptor/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   # https://pub.dev/packages/dio
-  dio: ">=4.0.0 <6.0.0"  
+  dio: ">=5.2.0+1 <6.0.0"  
   # https://pub.dev/packages/uuid
   uuid: ^3.0.7
   # https://pub.dev/packages/string_scanner

--- a/dio_cache_interceptor/pubspec.yaml
+++ b/dio_cache_interceptor/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dio HTTP cache interceptor with multiple stores respecting HTTP dir
 repository: https://github.com/llfbandit/dio_cache_interceptor
 issue_tracker: https://github.com/llfbandit/dio_cache_interceptor/issues
 
-version: 3.4.3
+version: 3.4.4
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -12,7 +12,7 @@ dependencies:
   # https://pub.dev/packages/dio
   dio: ">=5.2.0+1 <6.0.0"  
   # https://pub.dev/packages/uuid
-  uuid: ^3.0.7
+  uuid: ">=3.0.7 <5.0.0"
   # https://pub.dev/packages/string_scanner
   string_scanner: ^1.1.0
 

--- a/dio_cache_interceptor/pubspec.yaml
+++ b/dio_cache_interceptor/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dio HTTP cache interceptor with multiple stores respecting HTTP dir
 repository: https://github.com/llfbandit/dio_cache_interceptor
 issue_tracker: https://github.com/llfbandit/dio_cache_interceptor/issues
 
-version: 3.4.1
+version: 3.4.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/dio_cache_interceptor/test/cache_control_test.dart
+++ b/dio_cache_interceptor/test/cache_control_test.dart
@@ -37,14 +37,14 @@ void main() {
       expires: null,
       cacheControl: CacheControl(),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(resp.isExpired(CacheControl()), isTrue);
 
     resp = buildResponse(
       date: DateTime.now().subtract(const Duration(seconds: 12)),
       expires: null,
       cacheControl: CacheControl(maxAge: 10),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(resp.isExpired(CacheControl()), isTrue);
 
     // max-age takes precedence over expires
     resp = buildResponse(
@@ -52,7 +52,7 @@ void main() {
       expires: DateTime.now().add(const Duration(hours: 10)),
       cacheControl: CacheControl(maxAge: 10),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(resp.isExpired(CacheControl()), isTrue);
 
     // max-age is invalid check with expires
     resp = buildResponse(
@@ -60,21 +60,21 @@ void main() {
       expires: DateTime.now().add(const Duration(hours: 10)),
       cacheControl: CacheControl(maxAge: 0),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(resp.isExpired(CacheControl()), isTrue);
 
     resp = buildResponse(
       date: null,
       expires: DateTime.now().subtract(const Duration(hours: 10)),
       cacheControl: CacheControl(),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(resp.isExpired(CacheControl()), isTrue);
 
     resp = buildResponse(
       date: DateTime.now(),
       expires: DateTime.now().add(const Duration(hours: 10)),
       cacheControl: CacheControl(),
     );
-    expect(resp.isExpired(requestCaching: CacheControl()), isFalse);
+    expect(resp.isExpired(CacheControl()), isFalse);
   });
 
   void compareCacheControls(CacheControl cc1, CacheControl cc2) {

--- a/dio_cache_interceptor/test/cache_interceptor_test.dart
+++ b/dio_cache_interceptor/test/cache_interceptor_test.dart
@@ -190,7 +190,7 @@ void main() {
         ),
       );
     } catch (err) {
-      expect((err as DioError).response?.statusCode, equals(500));
+      expect((err as DioException).response?.statusCode, equals(500));
     }
 
     try {
@@ -207,7 +207,7 @@ void main() {
         ),
       );
     } catch (err) {
-      expect((err as DioError).response?.statusCode, equals(500));
+      expect((err as DioException).response?.statusCode, equals(500));
       return;
     }
 

--- a/dio_cache_interceptor/test/cache_interceptor_test.dart
+++ b/dio_cache_interceptor/test/cache_interceptor_test.dart
@@ -34,8 +34,6 @@ void main() {
     );
   });
 
-  // TODO re-enable this test when Dio team has fixed CancelToken().cancel()
-  // new behaviour
   // test('Fetch canceled', () async {
   //   try {
   //     await dio.get(
@@ -301,10 +299,10 @@ void main() {
     expect(cacheResp, isNotNull);
 
     // We're before max-age: 1
-    expect(cacheResp!.isExpired(requestCaching: CacheControl()), isFalse);
+    expect(cacheResp!.isExpired(CacheControl()), isFalse);
     // We're after max-age: 1
     await Future.delayed(const Duration(seconds: 1));
-    expect(cacheResp.isExpired(requestCaching: CacheControl()), isTrue);
+    expect(cacheResp.isExpired(CacheControl()), isTrue);
   });
 
   test('Skip downloads', () async {

--- a/dio_cache_interceptor/test/content_serialization_test.dart
+++ b/dio_cache_interceptor/test/content_serialization_test.dart
@@ -55,4 +55,17 @@ void main() {
     );
     expect(deserializedContent, equals(content));
   });
+
+  test('Serialize null', () async {
+    final serializedContent = await serializeContent(
+      ResponseType.json,
+      null,
+    );
+    final deserializedContent = await deserializeContent(
+      ResponseType.json,
+      serializedContent,
+    );
+
+    expect(deserializedContent, isNull);
+  });
 }

--- a/dio_cache_interceptor/test/mock_httpclient_adapter.dart
+++ b/dio_cache_interceptor/test/mock_httpclient_adapter.dart
@@ -69,7 +69,7 @@ class MockHttpClientAdapter implements HttpClientAdapter {
         );
       case '/exception':
         if (options.extra.containsKey('x-err')) {
-          throw DioError(requestOptions: options);
+          throw DioException(requestOptions: options);
         }
 
         return ResponseBody.fromString(

--- a/dio_cache_interceptor_db_store/example/pubspec.lock
+++ b/dio_cache_interceptor_db_store/example/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -122,18 +122,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -283,6 +283,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -300,5 +308,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_db_store/pubspec.lock
+++ b/dio_cache_interceptor_db_store/pubspec.lock
@@ -634,4 +634,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/dio_cache_interceptor_hive_store/example/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   crypto:
     dependency: transitive
     description:
@@ -86,14 +86,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
@@ -106,18 +98,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
@@ -251,6 +243,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
@@ -268,5 +268,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_hive_store/example/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -106,10 +106,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -247,10 +247,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -268,5 +268,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_hive_store/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/pubspec.lock
@@ -402,4 +402,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/dio_cache_interceptor_sembast_storage/example/pubspec.lock
+++ b/dio_cache_interceptor_sembast_storage/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -78,14 +78,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
@@ -98,18 +90,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -259,6 +251,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -276,5 +276,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
In Dio a `304 not modified` can be configured to be a valid status:
`BaseOptions(validateStatus: (status) => status != null && ((status >= 200 && status < 300) || status == 304))`

This PR allows 304's to be handled in the onResponse flow. 
This way (having `not modified` as a valid status) the usual chain of onResponse interceptors will still trigger, unlike the error flow.